### PR TITLE
Fix server module imports

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+import sys
 
 from flask import Flask, request, send_file, after_this_request
 from flask_cors import CORS
+
+# Ensure the repository root is on the Python path so that this script can be
+# executed directly from the ``server`` directory or via ``python server/app.py``
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 import pdf_text_extractor
 


### PR DESCRIPTION
## Summary
- ensure `server/app.py` can find project modules when run from inside the server directory

## Testing
- `python pdf_text_extractor.py -h`
- `python server/app.py & sleep 3; pkill -f server/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685ad8e68d4c832a9399ddfe13b728bc